### PR TITLE
chore: add scoped feature and question templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature request
+description: Suggest a feature that fits this repository's actual scope and workflow.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting:
+
+        - Read the README first.
+        - Make sure this request is about **this repository itself**, not a vague upstream idea or a request for unrelated functionality.
+        - Do **not** use this form for basic usage questions or requests already answered by the README.
+
+        Feature requests that ignore documented behavior, duplicate existing workflow, or fall outside this project's scope may be closed without further discussion.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I read the README and this request is not already answered by the documented workflow.
+          required: true
+        - label: This request is specifically about this repository, not just upstream/offical Qwen3-TTS behavior.
+          required: true
+        - label: I am proposing a concrete improvement, not asking a general support question.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem is this feature solving?
+      description: Describe the concrete pain point in this repository's real workflow.
+      placeholder: What is missing or painful right now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_workflow
+    attributes:
+      label: Current workflow you tried
+      description: Show that you actually tried the existing project flow first.
+      placeholder: |
+        I followed README section ...
+        I ran ...
+        The limitation was ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you want in a concrete way.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Why does this belong in this project?
+      description: Explain why this should live here instead of upstream or in user-specific custom tooling.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. What did you try or consider instead?

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,69 @@
+name: Project question
+description: Ask a question about this repository after checking the README and trying the documented workflow.
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting:
+
+        - Read the README first.
+        - Try the documented workflow first.
+        - Keep the question scoped to **this repository**.
+
+        Issues that are really upstream questions, vague "can it do X" requests, or questions already answered by the README may be closed without reply.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I read the README before opening this question.
+          required: true
+        - label: I tried the documented workflow or setup before asking.
+          required: true
+        - label: This question is about this repository itself, not a generic upstream or theoretical question.
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Ask one clear, concrete question.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_tried
+    attributes:
+      label: What have you already tried?
+      description: Show the exact workflow, command, or README section you already followed.
+      placeholder: |
+        I followed README section ...
+        I ran ...
+        I checked ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Relevant environment details
+      description: Include OS, install method, Python/CUDA/GPU details if relevant to the question.
+      placeholder: |
+        OS:
+        Install method:
+        Python:
+        CUDA:
+        GPU:
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Optional but strongly recommended when the question is about a failure or unexpected behavior.
+      render: shell


### PR DESCRIPTION
## Summary
- add a feature request form scoped to this repository
- add a project question form that requires README-first and try-first behavior
- make it easier to close vague upstream, theoretical, or no-effort issue submissions

## Why
The issue tracker should be for this project's real workflow, not a catch-all bucket for people who did not read the README or test anything first.