### PR TITLE
feat: pre-computed speaker embeddings — enables CustomVoice/VoiceDesign fine-tuning

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -160,7 +160,8 @@ def cmd_tokenize(args):
             print(f"  ❌ File {input_jsonl} not found.")
             sys.exit(1)
     
-    resolved_tokenizer = get_model_path("Qwen/Qwen3-TTS-Tokenizer-12Hz", use_hf=False)
+    use_hf = args.model_source == "HuggingFace"
+    resolved_tokenizer = get_model_path("Qwen/Qwen3-TTS-Tokenizer-12Hz", use_hf=use_hf)
     device = "cuda:0" if args.gpu != "cpu" else "cpu"
     
     consume_generator(run_prepare(device, resolved_tokenizer, input_jsonl, output_codes_jsonl))
@@ -421,6 +422,7 @@ Examples:
     p_tokenize = subparsers.add_parser("tokenize", help="Step 3: Data Tokenization")
     p_tokenize.add_argument("--speaker_name", type=str, required=True, help="Speaker name(s), comma-separated for multi-speaker")
     p_tokenize.add_argument("--experiment_name", type=str, required=True, help="Experiment name for saving logs/codes")
+    p_tokenize.add_argument("--model_source", type=str, choices=["HuggingFace", "ModelScope"], default="HuggingFace")
     p_tokenize.add_argument("--gpu", type=str, default="cuda:0")
 
     # ── train ──

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -126,7 +126,6 @@ class TTSDataset(Dataset):
         text        = item["text"]
         audio_codes = item["audio_codes"]
         language        = item.get('language','Auto')
-        ref_audio_path  = item['ref_audio']
         speaker_id      = item.get('speaker_id', self.default_speaker)
 
         text = self._build_assistant_text(text)
@@ -134,16 +133,9 @@ class TTSDataset(Dataset):
 
         audio_codes = torch.tensor(audio_codes, dtype=torch.long)
 
-        ref_audio_list = self._ensure_list(ref_audio_path)
-        normalized = self._normalize_audio_inputs(ref_audio_list)
-        wav,sr = normalized[0]
-
-        ref_mel = self.extract_mels(audio=wav, sr=sr)
-
         return {
-            "text_ids": text_ids[:,:-5],    # 1 , t
-            "audio_codes":audio_codes,      # t, 16
-            "ref_mel":ref_mel,
+            "text_ids": text_ids[:,:-5],
+            "audio_codes":audio_codes,
             "speaker_id": speaker_id
         }
         
@@ -207,14 +199,10 @@ class TTSDataset(Dataset):
             codec_mask[i,   8+text_ids_len-1:8+text_ids_len-1+codec_ids_len] = True
             attention_mask[i, :8+text_ids_len+codec_ids_len] = True
         
-        # Keep ref_mels as a list of variable-length tensors (each shape: 1, time, 128)
-        # They will be processed per-sample in the training loop to avoid padding artifacts
-        ref_mels = [data['ref_mel'] for data in batch]
         speaker_ids = [data['speaker_id'] for data in batch]
 
         return {
             'input_ids':input_ids,
-            'ref_mels':ref_mels,
             'attention_mask':attention_mask,
             'text_embedding_mask':text_embedding_mask.unsqueeze(-1),
             'codec_embedding_mask':codec_embedding_mask.unsqueeze(-1),

--- a/src/embed_speaker.py
+++ b/src/embed_speaker.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Pre-compute speaker embeddings from reference audio(s).
+
+This script extracts speaker embeddings using the Base model's speaker_encoder
+and saves them as safetensors. The training loop can then load these pre-computed
+embeddings directly, avoiding redundant GPU computation in every training step.
+
+Usage:
+  # Per-speaker ref from JSONL (default)
+  python scripts/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-0.6B-Base
+
+  # Average all audio per speaker
+  python scripts/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-1.7B-Base --mode avg_all
+
+  # Custom ref audio for a single speaker
+  python scripts/embed_speaker.py --speaker my_speaker --ref /path/to/ref.wav
+
+  # Multi-ref averaging
+  python scripts/embed_speaker.py --speaker my_speaker --ref a.wav,b.wav,c.wav
+
+Output: final-dataset/{speaker}/speaker_emb.safetensors (1024-dim tensor)
+"""
+
+import torch, os, sys, json, gc, argparse, numpy as np
+import librosa
+from qwen_tts import Qwen3TTSModel
+from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
+
+
+def load_speaker_encoder(model_id="Qwen/Qwen3-TTS-12Hz-1.7B-Base"):
+    """Load Base model just for its speaker_encoder."""
+    base = Qwen3TTSModel.from_pretrained(
+        model_id,
+        device_map="cuda:0", torch_dtype=torch.bfloat16,
+        attn_implementation="flash_attention_2",
+    )
+    se = base.model.speaker_encoder.to("cuda:0")
+    del base
+    gc.collect()
+    torch.cuda.empty_cache()
+    return se
+
+
+def extract_embedding(se, audio_path):
+    """Extract 1024-dim speaker embedding from audio file."""
+    audio, sr = librosa.load(audio_path, sr=24000, mono=True)
+    mel = mel_spectrogram(
+        torch.from_numpy(audio).unsqueeze(0).to("cuda:0"),
+        n_fft=1024, num_mels=128, sampling_rate=24000,
+        hop_size=256, win_size=1024, fmin=0, fmax=12000,
+    ).transpose(1, 2).to(torch.bfloat16)
+    with torch.no_grad():
+        emb = se(mel).detach()  # [1, 1024]
+    return emb[0].cpu()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base_model", default="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+                        help="Base model HF ID for speaker_encoder extraction")
+    parser.add_argument("--mode", default="ref", choices=["ref", "avg_all"],
+                        help="ref=use ref_audio from JSONL, avg_all=average all samples per speaker")
+    parser.add_argument("--speaker", default=None, help="Process single speaker")
+    parser.add_argument("--ref", default=None, help="Custom ref audio(s), comma-separated")
+    parser.add_argument("--output", default=None, help="Custom output path")
+    args = parser.parse_args()
+
+    se = load_speaker_encoder(args.base_model)
+
+    dataset_path = "final-dataset"
+    if not os.path.isdir(dataset_path):
+        print("final-dataset/ not found. Run the data pipeline first.")
+        sys.exit(1)
+
+    speakers = [args.speaker] if args.speaker else [
+        d for d in os.listdir(dataset_path)
+        if os.path.isdir(os.path.join(dataset_path, d))
+    ]
+
+    # Embeddings go alongside speaker data in final-dataset/
+        spk_dir = os.path.join(dataset_path, spk)
+        jsonl = os.path.join(spk_dir, "tts_train.jsonl")
+        audio_dir = os.path.join(spk_dir, "audio_24k")
+        out_path = args.output or os.path.join(spk_dir, "speaker_emb.safetensors")
+
+        embeddings = []
+
+        if args.ref:
+            for ref_file in args.ref.split(","):
+                ref_file = ref_file.strip()
+                if not os.path.isabs(ref_file):
+                    ref_file = os.path.join(audio_dir, ref_file)
+                if os.path.exists(ref_file):
+                    print(f"  {spk}: {os.path.basename(ref_file)}")
+                    embeddings.append(extract_embedding(se, ref_file))
+        elif args.mode == "avg_all":
+            if os.path.exists(jsonl):
+                with open(jsonl) as f:
+                    entries = [json.loads(line) for line in f]
+                for entry in entries:
+                    audio_path = entry.get("audio")
+                    if audio_path and os.path.exists(audio_path):
+                        embeddings.append(extract_embedding(se, audio_path))
+                print(f"  {spk}: averaged {len(entries)} samples")
+            else:
+                print(f"  {spk}: no JSONL, skipping")
+                continue
+        else:
+            # Default: use ref_audio from JSONL (set by Step 2 pipeline)
+            if os.path.exists(jsonl):
+                with open(jsonl) as f:
+                    entries = [json.loads(line) for line in f]
+                if entries:
+                    ref = entries[0].get("ref_audio")
+                    if ref and os.path.exists(ref):
+                        print(f"  {spk}: {os.path.basename(ref)}")
+                        embeddings.append(extract_embedding(se, ref))
+                    else:
+                        print(f"  {spk}: ref_audio not found in JSONL, skipping")
+                        continue
+                else:
+                    print(f"  {spk}: JSONL is empty, skipping")
+                    continue
+            else:
+                print(f"  {spk}: no JSONL, skipping")
+                continue
+
+        if embeddings:
+            avg_emb = torch.stack(embeddings).mean(dim=0).squeeze(0)  # [D]
+            from safetensors.torch import save_file
+            save_file({"emb": avg_emb}, out_path)
+            print(f"  → saved {out_path} (norm={avg_emb.norm():.2f})")
+        else:
+            print(f"  {spk}: no embeddings extracted")
+
+    del se
+    gc.collect()
+    torch.cuda.empty_cache()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/embed_speaker.py
+++ b/src/embed_speaker.py
@@ -13,6 +13,9 @@ Usage:
   # Average all audio per speaker
   python src/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-1.7B-Base --mode avg_all
 
+  # Use HuggingFace instead of the project's default model source
+  python src/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-0.6B-Base --model_source HuggingFace
+
   # Custom ref audio for a single speaker
   python src/embed_speaker.py --speaker my_speaker --ref /path/to/ref.wav
 
@@ -32,6 +35,7 @@ import torch
 import librosa
 from qwen_tts import Qwen3TTSModel
 from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
+from utils import get_model_path
 
 
 def get_runtime_device():
@@ -72,6 +76,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--base_model", default="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
                         help="Base model HF ID for speaker_encoder extraction")
+    parser.add_argument("--model_source", default="ModelScope", choices=["HuggingFace", "ModelScope"],
+                        help="Model download source, consistent with the rest of the project")
     parser.add_argument("--mode", default="ref", choices=["ref", "avg_all"],
                         help="ref=use ref_audio from JSONL, avg_all=average all samples per speaker")
     parser.add_argument("--speaker", default=None, help="Process single speaker")
@@ -80,8 +86,11 @@ def main():
     args = parser.parse_args()
 
     device = get_runtime_device()
+    use_hf = args.model_source == "HuggingFace"
+    resolved_base_model = get_model_path(args.base_model, use_hf=use_hf)
     print(f"Loading speaker_encoder from {args.base_model}")
-    se = load_speaker_encoder(args.base_model, device=device)
+    print(f"Resolved model path: {resolved_base_model}")
+    se = load_speaker_encoder(resolved_base_model, device=device)
 
     dataset_path = "final-dataset"
     if not os.path.isdir(dataset_path):

--- a/src/embed_speaker.py
+++ b/src/embed_speaker.py
@@ -38,7 +38,7 @@ def get_runtime_device():
     return "cuda:0" if torch.cuda.is_available() else "cpu"
 
 
-def load_speaker_encoder(model_id="Qwen/Qwen3-TTS-12Hz-1.7B-Base", device="cuda:0"):
+def load_speaker_encoder(model_id="Qwen/Qwen3-TTS-12Hz-0.6B-Base", device="cuda:0"):
     """Load Base model just for its speaker_encoder."""
     base = Qwen3TTSModel.from_pretrained(
         model_id,
@@ -70,7 +70,7 @@ def extract_embedding(se, audio_path, device):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base_model", default="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+    parser.add_argument("--base_model", default="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
                         help="Base model HF ID for speaker_encoder extraction")
     parser.add_argument("--mode", default="ref", choices=["ref", "avg_all"],
                         help="ref=use ref_audio from JSONL, avg_all=average all samples per speaker")
@@ -80,6 +80,7 @@ def main():
     args = parser.parse_args()
 
     device = get_runtime_device()
+    print(f"Loading speaker_encoder from {args.base_model}")
     se = load_speaker_encoder(args.base_model, device=device)
 
     dataset_path = "final-dataset"

--- a/src/embed_speaker.py
+++ b/src/embed_speaker.py
@@ -8,48 +8,61 @@ embeddings directly, avoiding redundant GPU computation in every training step.
 
 Usage:
   # Per-speaker ref from JSONL (default)
-  python scripts/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-0.6B-Base
+  python src/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-0.6B-Base
 
   # Average all audio per speaker
-  python scripts/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-1.7B-Base --mode avg_all
+  python src/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-1.7B-Base --mode avg_all
 
   # Custom ref audio for a single speaker
-  python scripts/embed_speaker.py --speaker my_speaker --ref /path/to/ref.wav
+  python src/embed_speaker.py --speaker my_speaker --ref /path/to/ref.wav
 
   # Multi-ref averaging
-  python scripts/embed_speaker.py --speaker my_speaker --ref a.wav,b.wav,c.wav
+  python src/embed_speaker.py --speaker my_speaker --ref a.wav,b.wav,c.wav
 
 Output: final-dataset/{speaker}/speaker_emb.safetensors (1024-dim tensor)
 """
 
-import torch, os, sys, json, gc, argparse, numpy as np
+import argparse
+import gc
+import json
+import os
+import sys
+
+import torch
 import librosa
 from qwen_tts import Qwen3TTSModel
 from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
 
 
-def load_speaker_encoder(model_id="Qwen/Qwen3-TTS-12Hz-1.7B-Base"):
+def get_runtime_device():
+    return "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def load_speaker_encoder(model_id="Qwen/Qwen3-TTS-12Hz-1.7B-Base", device="cuda:0"):
     """Load Base model just for its speaker_encoder."""
     base = Qwen3TTSModel.from_pretrained(
         model_id,
-        device_map="cuda:0", torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
+        device_map=device,
+        torch_dtype=torch.bfloat16 if device.startswith("cuda") else torch.float32,
+        attn_implementation="flash_attention_2" if device.startswith("cuda") else "eager",
     )
-    se = base.model.speaker_encoder.to("cuda:0")
+    se = base.model.speaker_encoder.to(device)
     del base
     gc.collect()
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     return se
 
 
-def extract_embedding(se, audio_path):
+def extract_embedding(se, audio_path, device):
     """Extract 1024-dim speaker embedding from audio file."""
     audio, sr = librosa.load(audio_path, sr=24000, mono=True)
     mel = mel_spectrogram(
-        torch.from_numpy(audio).unsqueeze(0).to("cuda:0"),
+        torch.from_numpy(audio).unsqueeze(0).to(device),
         n_fft=1024, num_mels=128, sampling_rate=24000,
         hop_size=256, win_size=1024, fmin=0, fmax=12000,
-    ).transpose(1, 2).to(torch.bfloat16)
+    ).transpose(1, 2)
+    mel = mel.to(torch.bfloat16 if device.startswith("cuda") else torch.float32)
     with torch.no_grad():
         emb = se(mel).detach()  # [1, 1024]
     return emb[0].cpu()
@@ -66,7 +79,8 @@ def main():
     parser.add_argument("--output", default=None, help="Custom output path")
     args = parser.parse_args()
 
-    se = load_speaker_encoder(args.base_model)
+    device = get_runtime_device()
+    se = load_speaker_encoder(args.base_model, device=device)
 
     dataset_path = "final-dataset"
     if not os.path.isdir(dataset_path):
@@ -78,7 +92,8 @@ def main():
         if os.path.isdir(os.path.join(dataset_path, d))
     ]
 
-    # Embeddings go alongside speaker data in final-dataset/
+    for spk in speakers:
+        # Embeddings go alongside speaker data in final-dataset/
         spk_dir = os.path.join(dataset_path, spk)
         jsonl = os.path.join(spk_dir, "tts_train.jsonl")
         audio_dir = os.path.join(spk_dir, "audio_24k")
@@ -93,7 +108,7 @@ def main():
                     ref_file = os.path.join(audio_dir, ref_file)
                 if os.path.exists(ref_file):
                     print(f"  {spk}: {os.path.basename(ref_file)}")
-                    embeddings.append(extract_embedding(se, ref_file))
+                    embeddings.append(extract_embedding(se, ref_file, device))
         elif args.mode == "avg_all":
             if os.path.exists(jsonl):
                 with open(jsonl) as f:
@@ -101,7 +116,7 @@ def main():
                 for entry in entries:
                     audio_path = entry.get("audio")
                     if audio_path and os.path.exists(audio_path):
-                        embeddings.append(extract_embedding(se, audio_path))
+                        embeddings.append(extract_embedding(se, audio_path, device))
                 print(f"  {spk}: averaged {len(entries)} samples")
             else:
                 print(f"  {spk}: no JSONL, skipping")
@@ -115,7 +130,7 @@ def main():
                     ref = entries[0].get("ref_audio")
                     if ref and os.path.exists(ref):
                         print(f"  {spk}: {os.path.basename(ref)}")
-                        embeddings.append(extract_embedding(se, ref))
+                        embeddings.append(extract_embedding(se, ref, device))
                     else:
                         print(f"  {spk}: ref_audio not found in JSONL, skipping")
                         continue
@@ -136,7 +151,8 @@ def main():
 
     del se
     gc.collect()
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     print("\nDone.")
 
 

--- a/src/sft_12hz.py
+++ b/src/sft_12hz.py
@@ -436,6 +436,28 @@ def run_train(
             else:
                 print(msg)
 
+        import os as _os
+        missing = []
+        log_print("Loading pre-computed speaker embeddings...")
+        for spk in speaker_names:
+            emb_path = _os.path.join(root_dir, "final-dataset", spk, "speaker_emb.safetensors")
+            if _os.path.exists(emb_path):
+                from safetensors.torch import load_file
+                emb = load_file(emb_path)["emb"]
+                if isinstance(emb, torch.Tensor):
+                    emb = emb.squeeze(0) if emb.dim() == 2 else emb
+                    speaker_embeddings[spk] = emb
+                    log_print(f"  {spk}: loaded (norm={emb.norm():.2f})")
+                else:
+                    missing.append(spk)
+            else:
+                missing.append(spk)
+        if missing:
+            msg = f"Missing speaker embeddings for: {', '.join(missing)}. Run embed_speaker.py first."
+            log_print(msg)
+            yield {"type": "error", "msg": msg}
+            return
+
         log_print(f"Multi-speaker mode: {len(speaker_names)} speakers")
         for name, sid in spk_id_map.items():
             log_print(f"  Speaker '{name}' -> spk_id {sid}")
@@ -598,7 +620,6 @@ def run_train(
 
                     input_ids = batch["input_ids"].to(model_device)
                     codec_ids = batch["codec_ids"].to(model_device)
-                    ref_mels_list = batch["ref_mels"]
                     text_embedding_mask = batch["text_embedding_mask"].to(model_device)
                     codec_embedding_mask = batch["codec_embedding_mask"].to(model_device)
                     attention_mask = batch["attention_mask"].to(model_device)
@@ -608,14 +629,10 @@ def run_train(
                     with autocast_context:
                         per_sample_embeddings = []
                         batch_speaker_ids = batch["speaker_ids"]
-                        for b_idx, ref_mel in enumerate(ref_mels_list):
-                            emb = unwrap_model.speaker_encoder(ref_mel.to(model_device).to(model_dtype)).detach()
-                            per_sample_embeddings.append(emb)
-
+                        for b_idx in range(len(batch_speaker_ids)):
                             sid = batch_speaker_ids[b_idx]
-                            if sid not in speaker_embeddings:
-                                speaker_embeddings[sid] = emb[0].cpu()
-                                log_print(f"Captured embedding for speaker '{sid}'")
+                            emb = speaker_embeddings[sid].unsqueeze(0).to(model_device).to(model_dtype)
+                            per_sample_embeddings.append(emb)
 
                         speaker_embedding = torch.cat(per_sample_embeddings, dim=0)
 
@@ -695,13 +712,6 @@ def run_train(
                     writer.add_scalar("train/epoch_index", epoch, global_step)
                     writer.add_scalar("train/step_in_epoch", step, global_step)
                     writer.flush()
-
-                if is_main_process and step % 500 == 0:
-                    try:
-                        mel_vis = plot_spectrogram_to_numpy(ref_mels_list[0][0].detach().cpu().float().numpy())
-                        writer.add_image("train/ref_mel", mel_vis, global_step, dataformats="HWC")
-                    except Exception as e:
-                        log_print(f"Error logging Mel to Tensorboard: {e}")
 
                 should_save_step_checkpoint = (
                     is_main_process

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,20 +29,28 @@ def get_model_local_dir(model_id):
 def is_model_dir_ready(path):
     if not path or not os.path.isdir(path):
         return False
-    marker_files = (
-        'config.json',
-        'tokenizer_config.json',
-        'preprocessor_config.json',
+
+    payload_markers = (
+        'model.safetensors',
         'model.safetensors.index.json',
+        'pytorch_model.bin',
         'pytorch_model.bin.index.json',
+        'tf_model.h5',
+        'model.ckpt.index',
+        'flax_model.msgpack',
+        'tokenizer.json',
+        'tokenizer.model',
     )
-    if any(os.path.exists(os.path.join(path, marker)) for marker in marker_files):
+
+    if any(os.path.exists(os.path.join(path, marker)) for marker in payload_markers):
         return True
+
     try:
         entries = os.listdir(path)
     except OSError:
         return False
-    return any(entry.endswith(('.safetensors', '.bin', '.json', '.model')) for entry in entries)
+
+    return any(entry.endswith(('.safetensors', '.bin', '.model')) for entry in entries)
 
 
 

--- a/src/webui.py
+++ b/src/webui.py
@@ -214,7 +214,7 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
     if isinstance(speaker_name, list):
         speaker_names = [s.strip() for s in speaker_name if s.strip()]
     elif isinstance(speaker_name, str):
-        speaker_names = [s.strip() for s in speaker_name.split(',') if s.strip()]
+        speaker_names = [s.strip() for s in speaker_name.split(",") if s.strip()]
     else:
         speaker_names = []
 
@@ -228,6 +228,7 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
     output_jsonl = os.path.join(log_dir, "tts_train_with_codes.jsonl")
 
     if len(speaker_names) > 1:
+        # Merge multi-speaker
         merged_jsonl = os.path.join(log_dir, "tts_train_merged.jsonl")
         total_merged = 0
         with open(merged_jsonl, 'w', encoding='utf-8') as f_out:
@@ -243,7 +244,7 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
                         entry['speaker_id'] = spk_name
                         f_out.write(json.dumps(entry, ensure_ascii=False) + '\n')
                         total_merged += 1
-        yield f"Merged {total_merged} entries from {len(speaker_names)} speakers. Starting tokenization..."
+            print(f"    Merged {total_merged} entries from {len(speaker_names)} speakers.")
         input_jsonl = merged_jsonl
     else:
         speaker_dir = resolve_path(os.path.join("final-dataset", speaker_names[0]))
@@ -254,9 +255,77 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
 
     resolved_tokenizer = get_model_path("Qwen/Qwen3-TTS-Tokenizer-12Hz", use_hf=False)
     device = "cuda:0" if gpu_id != "cpu" else "cpu"
-    os.environ["CUDA_VISIBLE_DEVICES"] = gpu_id.replace("cuda:", "") if gpu_id != "cpu" else ""
-    stream = stream_isolated(internal_run_prepare, device, resolved_tokenizer, input_jsonl, output_jsonl)
+    stream = stream_isolated(internal_run_prepare, input_jsonl, output_jsonl, resolved_tokenizer, batch_size=2, device=device)
     yield from stream_worker_updates(stream, progress)
+
+
+def run_embed_speakers(speaker_name, base_model="Qwen/Qwen3-TTS-12Hz-1.7B-Base", progress=gr.Progress()):
+    """Pre-compute speaker embeddings from reference audio."""
+    if isinstance(speaker_name, list):
+        speakers = [s.strip() for s in speaker_name if s.strip()]
+    elif isinstance(speaker_name, str):
+        speakers = [s.strip() for s in speaker_name.split(",") if s.strip()]
+    else:
+        yield "Please select speakers."
+        return
+
+    progress(0.1, desc="Loading speaker_encoder...")
+    import torch, librosa, json
+    from qwen_tts import Qwen3TTSModel
+    from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
+    from safetensors.torch import save_file
+
+    base = Qwen3TTSModel.from_pretrained(
+        base_model,
+        device_map="cuda:0", torch_dtype=torch.bfloat16,
+        attn_implementation="flash_attention_2",
+    )
+    se = base.model.speaker_encoder.to("cuda:0")
+    del base
+    import gc
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    msgs = []
+    for spk in speakers:
+        jsonl = resolve_path(f"final-dataset/{spk}/tts_train.jsonl")
+        if not os.path.exists(jsonl):
+            msgs.append(f"{spk}: no JSONL, skip")
+            continue
+
+        out_path = resolve_path(f"final-dataset/{spk}/speaker_emb.safetensors")
+
+        # Use ref_audio from first JSONL entry (set by Step 2 pipeline)
+        with open(jsonl) as f:
+            entries = [json.loads(line) for line in f]
+        if not entries:
+            msgs.append(f"{spk}: JSONL is empty, skip")
+            continue
+        ref = entries[0].get("ref_audio")
+        if not ref or not os.path.exists(ref):
+            msgs.append(f"{spk}: ref_audio not found in JSONL, skip")
+            continue
+
+        progress(0.3 + 0.6 * (speakers.index(spk) / max(len(speakers), 1)),
+                 desc=f"Embedding {spk}...")
+        audio, sr = librosa.load(ref, sr=24000, mono=True)
+        mel = mel_spectrogram(
+            torch.from_numpy(audio).unsqueeze(0).to("cuda:0"),
+            n_fft=1024, num_mels=128, sampling_rate=24000,
+            hop_size=256, win_size=1024, fmin=0, fmax=12000,
+        ).transpose(1, 2).to(torch.bfloat16)
+        with torch.no_grad():
+            emb = se(mel).detach().cpu()
+
+        avg_emb = emb[0].squeeze(0) if emb.dim() == 2 else emb.squeeze(0)
+        save_file({"emb": avg_emb}, out_path)
+        msgs.append(f"{spk}: norm={avg_emb.norm():.2f}")
+
+    del se
+    gc.collect()
+    torch.cuda.empty_cache()
+    progress(1.0, desc="Done")
+    yield "\n".join(msgs)
 
 # ----------------- Download Model -----------------
 def check_or_download_model(init_model, model_source, progress=gr.Progress()):
@@ -764,7 +833,8 @@ with gr.Blocks(title="Qwen3-TTS Easy Finetuning", css=css) as app:
                         scale=1
                     )
                 step3_btn = gr.Button("▶️ Tokenize Data", variant="primary")
-                step3_out = gr.Textbox(label="Tokenization Logs", lines=1)
+                embed_btn = gr.Button("🎤 Embed Speakers", variant="secondary", size="sm")
+                step3_out = gr.Textbox(label="Tokenization / Embedding Logs", lines=2)
                 
             gr.Markdown("---")
             
@@ -885,6 +955,8 @@ with gr.Blocks(title="Qwen3-TTS Easy Finetuning", css=css) as app:
     
     # Step 3
     step3_btn.click(fn=run_step_3, inputs=[speaker_dropdown, experiment_dropdown, gpu_prep], outputs=[step3_out])
+    # Embed Speakers
+    embed_btn.click(fn=run_embed_speakers, inputs=[speaker_dropdown], outputs=[step3_out])
     
     # Utilities
     download_btn.click(fn=check_or_download_model, inputs=[init_model, model_source], outputs=[download_log])

--- a/src/webui.py
+++ b/src/webui.py
@@ -210,7 +210,7 @@ def run_step_2(speaker_name, asr_model, asr_source, gpu_id, progress=gr.Progress
     yield from stream_worker_updates(stream, progress)
 
 # ----------------- Step 3: Tokenization -----------------
-def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
+def run_step_3(speaker_name, experiment_name, gpu_id, model_source, progress=gr.Progress()):
     if isinstance(speaker_name, list):
         speaker_names = [s.strip() for s in speaker_name if s.strip()]
     elif isinstance(speaker_name, str):
@@ -253,7 +253,8 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
             yield f"Error: File {input_jsonl} not found. Please run Data Prep Step 1 & 2 first."
             return
 
-    resolved_tokenizer = get_model_path("Qwen/Qwen3-TTS-Tokenizer-12Hz", use_hf=False)
+    use_hf = model_source == "HuggingFace"
+    resolved_tokenizer = get_model_path("Qwen/Qwen3-TTS-Tokenizer-12Hz", use_hf=use_hf)
     device = "cuda:0" if gpu_id != "cpu" else "cpu"
     os.environ["CUDA_VISIBLE_DEVICES"] = gpu_id.replace("cuda:", "") if gpu_id != "cpu" else ""
     stream = stream_isolated(internal_run_prepare, device, resolved_tokenizer, input_jsonl, output_jsonl)
@@ -361,7 +362,7 @@ def check_or_download_model(init_model, model_source, progress=gr.Progress()):
         download_base_model.target_dir = get_model_local_dir(init_model)
         resolved_init_model = run_with_polling(download_base_model, progress, progress_start=0.05, progress_end=0.55, desc_prefix=f"Downloading base model {init_model}")
         def download_tokenizer_model():
-            return get_model_path(tokenizer_model_id, use_hf=False)
+            return get_model_path(tokenizer_model_id, use_hf=use_hf)
         download_tokenizer_model.target_dir = get_model_local_dir(tokenizer_model_id)
         resolved_tokenizer = run_with_polling(download_tokenizer_model, progress, progress_start=0.60, progress_end=0.98, desc_prefix=f"Downloading tokenizer {tokenizer_model_id}")
         progress(1.0, desc="All required models are ready")
@@ -977,7 +978,7 @@ with gr.Blocks(title="Qwen3-TTS Easy Finetuning", css=css) as app:
 
     
     # Step 3
-    step3_btn.click(fn=run_step_3, inputs=[speaker_dropdown, experiment_dropdown, gpu_prep], outputs=[step3_out])
+    step3_btn.click(fn=run_step_3, inputs=[speaker_dropdown, experiment_dropdown, gpu_prep, model_source], outputs=[step3_out])
     # Embed Speakers
     embed_btn.click(fn=run_embed_speakers, inputs=[speaker_dropdown, gpu_prep, init_model, model_source], outputs=[step3_out])
     

--- a/src/webui.py
+++ b/src/webui.py
@@ -255,11 +255,21 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
 
     resolved_tokenizer = get_model_path("Qwen/Qwen3-TTS-Tokenizer-12Hz", use_hf=False)
     device = "cuda:0" if gpu_id != "cpu" else "cpu"
-    stream = stream_isolated(internal_run_prepare, input_jsonl, output_jsonl, resolved_tokenizer, batch_size=2, device=device)
+    os.environ["CUDA_VISIBLE_DEVICES"] = gpu_id.replace("cuda:", "") if gpu_id != "cpu" else ""
+    stream = stream_isolated(internal_run_prepare, device, resolved_tokenizer, input_jsonl, output_jsonl)
     yield from stream_worker_updates(stream, progress)
 
 
-def run_embed_speakers(speaker_name, base_model="Qwen/Qwen3-TTS-12Hz-1.7B-Base", progress=gr.Progress()):
+def resolve_embed_base_model(model_name):
+    model_name = model_name.strip() if isinstance(model_name, str) else ""
+    if model_name.endswith("-Base"):
+        return model_name
+    if "0.6B" in model_name:
+        return "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+    return "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+
+
+def run_embed_speakers(speaker_name, gpu_id, model_name, progress=gr.Progress()):
     """Pre-compute speaker embeddings from reference audio."""
     if isinstance(speaker_name, list):
         speakers = [s.strip() for s in speaker_name if s.strip()]
@@ -269,18 +279,25 @@ def run_embed_speakers(speaker_name, base_model="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
         yield "Please select speakers."
         return
 
+    if gpu_id == "cpu":
+        yield "Speaker embedding currently requires a CUDA device."
+        return
+
+    base_model = resolve_embed_base_model(model_name)
+    device = "cuda:0"
     progress(0.1, desc="Loading speaker_encoder...")
     import torch, librosa, json
     from qwen_tts import Qwen3TTSModel
     from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
     from safetensors.torch import save_file
 
+    os.environ["CUDA_VISIBLE_DEVICES"] = gpu_id.replace("cuda:", "")
     base = Qwen3TTSModel.from_pretrained(
         base_model,
-        device_map="cuda:0", torch_dtype=torch.bfloat16,
+        device_map=device, torch_dtype=torch.bfloat16,
         attn_implementation="flash_attention_2",
     )
-    se = base.model.speaker_encoder.to("cuda:0")
+    se = base.model.speaker_encoder.to(device)
     del base
     import gc
     gc.collect()
@@ -310,7 +327,7 @@ def run_embed_speakers(speaker_name, base_model="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
                  desc=f"Embedding {spk}...")
         audio, sr = librosa.load(ref, sr=24000, mono=True)
         mel = mel_spectrogram(
-            torch.from_numpy(audio).unsqueeze(0).to("cuda:0"),
+            torch.from_numpy(audio).unsqueeze(0).to(device),
             n_fft=1024, num_mels=128, sampling_rate=24000,
             hop_size=256, win_size=1024, fmin=0, fmax=12000,
         ).transpose(1, 2).to(torch.bfloat16)
@@ -956,7 +973,7 @@ with gr.Blocks(title="Qwen3-TTS Easy Finetuning", css=css) as app:
     # Step 3
     step3_btn.click(fn=run_step_3, inputs=[speaker_dropdown, experiment_dropdown, gpu_prep], outputs=[step3_out])
     # Embed Speakers
-    embed_btn.click(fn=run_embed_speakers, inputs=[speaker_dropdown], outputs=[step3_out])
+    embed_btn.click(fn=run_embed_speakers, inputs=[speaker_dropdown, gpu_prep, init_model], outputs=[step3_out])
     
     # Utilities
     download_btn.click(fn=check_or_download_model, inputs=[init_model, model_source], outputs=[download_log])

--- a/src/webui.py
+++ b/src/webui.py
@@ -262,14 +262,18 @@ def run_step_3(speaker_name, experiment_name, gpu_id, progress=gr.Progress()):
 
 def resolve_embed_base_model(model_name):
     model_name = model_name.strip() if isinstance(model_name, str) else ""
+    if not model_name:
+        return "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
     if model_name.endswith("-Base"):
         return model_name
     if "0.6B" in model_name:
         return "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
-    return "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    if "1.7B" in model_name:
+        return "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    return "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
 
 
-def run_embed_speakers(speaker_name, gpu_id, model_name, progress=gr.Progress()):
+def run_embed_speakers(speaker_name, gpu_id, model_name, model_source, progress=gr.Progress()):
     """Pre-compute speaker embeddings from reference audio."""
     if isinstance(speaker_name, list):
         speakers = [s.strip() for s in speaker_name if s.strip()]
@@ -284,8 +288,10 @@ def run_embed_speakers(speaker_name, gpu_id, model_name, progress=gr.Progress())
         return
 
     base_model = resolve_embed_base_model(model_name)
+    use_hf = model_source == "HuggingFace"
+    resolved_base_model = get_model_path(base_model, use_hf=use_hf)
     device = "cuda:0"
-    progress(0.1, desc="Loading speaker_encoder...")
+    progress(0.1, desc=f"Loading speaker_encoder from {base_model}...")
     import torch, librosa, json
     from qwen_tts import Qwen3TTSModel
     from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
@@ -293,7 +299,7 @@ def run_embed_speakers(speaker_name, gpu_id, model_name, progress=gr.Progress())
 
     os.environ["CUDA_VISIBLE_DEVICES"] = gpu_id.replace("cuda:", "")
     base = Qwen3TTSModel.from_pretrained(
-        base_model,
+        resolved_base_model,
         device_map=device, torch_dtype=torch.bfloat16,
         attn_implementation="flash_attention_2",
     )
@@ -342,7 +348,7 @@ def run_embed_speakers(speaker_name, gpu_id, model_name, progress=gr.Progress())
     gc.collect()
     torch.cuda.empty_cache()
     progress(1.0, desc="Done")
-    yield "\n".join(msgs)
+    yield f"Using base speaker encoder: {base_model}\n" + "\n".join(msgs)
 
 # ----------------- Download Model -----------------
 def check_or_download_model(init_model, model_source, progress=gr.Progress()):
@@ -973,7 +979,7 @@ with gr.Blocks(title="Qwen3-TTS Easy Finetuning", css=css) as app:
     # Step 3
     step3_btn.click(fn=run_step_3, inputs=[speaker_dropdown, experiment_dropdown, gpu_prep], outputs=[step3_out])
     # Embed Speakers
-    embed_btn.click(fn=run_embed_speakers, inputs=[speaker_dropdown, gpu_prep, init_model], outputs=[step3_out])
+    embed_btn.click(fn=run_embed_speakers, inputs=[speaker_dropdown, gpu_prep, init_model, model_source], outputs=[step3_out])
     
     # Utilities
     download_btn.click(fn=check_or_download_model, inputs=[init_model, model_source], outputs=[download_log])


### PR DESCRIPTION
## Summary

Speaker embeddings are moved out of the training loop: pre-computed once via a standalone script and loaded from safetensors at startup. This achieves two goals:

1. **Enables fine-tuning from CustomVoice / VoiceDesign models.** CV/VD lack a built-in `speaker_encoder`, so real-time embedding extraction during training is impossible. `embed_speaker.py` borrows the speaker_encoder from a matching Base model, extracts embeddings offline, and the training loop reads them directly — no transplant or runtime encoder needed.
2. **Saves GPU time.** Embeddings are deterministic for fixed reference audio. Pre-computing once avoids redundant `speaker_encoder(ref_mel)` calls in every training step.

## What changed

**New: `src/embed_speaker.py`** (+148 lines)
- Standalone script to pre-compute speaker embeddings
- Loads Base model's `speaker_encoder` independently (works regardless of training starting model)
- Supports `--mode ref` (from `meta.json`) and `--mode avg_all` (average all samples)
- Accepts `--base_model` to choose which Base model to borrow the encoder from
- Outputs `speaker_emb.safetensors` (1024-dim) to `final-dataset/{speaker}/`

**`src/sft_12hz.py`** (+28 / −4)
- Pre-load `speaker_emb.safetensors` per speaker at training startup
- Abort with clear error if any speaker is missing (prompts to run `embed_speaker.py`)
- Replace runtime `speaker_encoder(ref_mel)` call with dictionary lookup from pre-computed embeddings
- Remove ref_mels from batch processing and TensorBoard mel logging (dead code)

**`src/dataset.py`** (−10)
- Remove `ref_mel` from `__getitem__` output and from `collate_fn` — no longer needed since embeddings are pre-computed
- Remove ref_mels tensor list from collated batch

**`src/webui.py`** (+88 / -2)
- New `run_embed_speakers()` function accessible from the Training tab
- "Embed Speakers" button next to "Tokenize Data" button

## Rationale: CV/VD Fine-Tuning

CustomVoice and VoiceDesign models lack a `speaker_encoder` in their state dict. The current training loop requires it: `model.speaker_encoder(ref_mel)` runs in every batch to capture speaker embeddings. Without it, training from CV/VD crashes.

This PR decouples embedding extraction from the training model:
```
python src/embed_speaker.py --base_model Qwen/Qwen3-TTS-12Hz-1.7B-Base
  → loads Base model → extracts speaker_encoder → computes embedding → saves safetensors

sft_12hz.py --init_model_path ...CustomVoice
  → loads pre-computed safetensors → speaker_embeddings[sid] (no runtime encoder needed)
```

Checkpoint export drops `speaker_encoder` keys (absent from CV/VD anyway) and sets `tts_model_type: custom_voice`, so the fine-tuned model loads and infers correctly with `generate_custom_voice(speaker, instruct=...)`.

## Performance

In the current workflow, `speaker_encoder(ref_mel)` runs in every training step for every sample. This is redundant because speaker embeddings are deterministic for fixed reference audio. Pre-computing once and loading at startup saves significant GPU time during training, especially for multi-speaker setups.

## Before

```python
emb = unwrap_model.speaker_encoder(ref_mel.to(model_device).to(model_dtype)).detach()
# ❌ CV/VD models crash here — no speaker_encoder attribute
```

## After

```python
emb = speaker_embeddings[sid].unsqueeze(0).to(model_device).to(model_dtype)
# ✅ Works for Base, CV, VD — embedding was pre-computed externally
```
